### PR TITLE
Add an RMap widget to four types of OSF pages

### DIFF
--- a/website/static/css/rmap.css
+++ b/website/static/css/rmap.css
@@ -1,0 +1,21 @@
+.rmap-panel {
+    position: relative;
+    padding: 15px;
+}
+
+.rmap-square {
+    margin-top: 100%;
+}
+
+.rmap {
+    position: absolute;
+    padding: 15px; /* Must match padding in rmap-panel, above */
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    border-width: 0;
+}
+

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -153,6 +153,9 @@
                  }'></div>
             </div>
         </div>
+
+    	<%include file="rmap_widget.mako"/>
+
     </div>
     <div class="col-sm-6">
         <div class="panel panel-default">

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -332,6 +332,8 @@
          </div>
         % endif
 
+   	<%include file="rmap_widget.mako"/>
+
         <!-- Show child on right if widgets -->
         % if addons:
             ${children()}

--- a/website/templates/rmap_widget.mako
+++ b/website/templates/rmap_widget.mako
@@ -1,0 +1,24 @@
+<link rel='stylesheet' href='/static/css/rmap.css' type='text/css' />
+
+<div class="panel panel-default">
+    <!-- Collapsible section header - copied from the Citations section -->
+    <div class="panel-heading clearfix">
+        <h3 class="panel-title"  style="padding-top: 3px">RMap Graph</h3>
+        <div class="pull-right">
+            <button class="btn btn-link project-toggle">
+		<i class="fa fa-angle-down"></i>
+	    </button>
+        </div>
+    </div>
+
+    <!-- Display a square panel containing a (currently) fixed RMap viewer -->
+    <div class="rmap-panel panel-body" style="display:none">
+	<!-- This div sets aside the proper space for a square RMap -->
+	<div class="rmap-square"></div>
+        <!-- Must use two-part iframe element or parent page does not finish loading -->
+        <iframe class="rmap" src="https://dev.rmap-project.org/appdev/resources/http%3A%2F%2Fosf.io%2Fndry9/widget">
+        </iframe>
+    </div>
+
+</div>
+


### PR DESCRIPTION
Add an RMap widget to four types of OSF pages: User, Project, Component and Repository.  The widget is added by inserting a single "include" element in the profile.mako template (for user pages) and the project.mako template (for the other three types of pages).

The include statement references a new template rmap_widget.mako that hosts the widget in an iframe.  This template uses a new CSS file rmap.css to control its layout.

This work was specified in card [DC-2326](https://scm.dataconservancy.org/issues/browse/DC-2326).
